### PR TITLE
fix can't move pdf in es5 version

### DIFF
--- a/pdf-viewer.js
+++ b/pdf-viewer.js
@@ -292,7 +292,8 @@ Polymer({
   },
 
   _handleTrack(evt) {
-    getDiff = (evt) => {
+    let tmp;
+    let getDiff = (evt) => {
       return {
         x: this._trackPos.x - evt.detail.x,
         y: this._trackPos.y -  evt.detail.y,


### PR DESCRIPTION
Undeclared variable error after transpiling in es5